### PR TITLE
libhdfs3 2.3.0 rebuilt against libprotobuf 3.20

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,3 @@
+# This needs to be removed after the pinning of libprotobuf has been adjusted.
+libprotobuf:
+- 3.20

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,10 @@ source:
     - CMakeLists.txt.diff
     - 84ebda7d.patch
     - cmake-minimum-req-version.patch
+    - missing-namespace-string-npos.patch
 
 build:
-  number: 2
+  number: 3
   # This package is a dependency of hdfs3, which is primarily used with HDFS on Linux.
   # There isn't libboost=1.73 and libgsasl=1.8 on s390x
   skip: True  # [win or osx or s390x]
@@ -34,7 +35,7 @@ requirements:
     - make   # [linux]
     - patch  # [not win]
   host:
-    - libprotobuf
+    - libprotobuf  # libprotobuf pins itself to x.x via run_exports
     - libgsasl
     - libntlm
     - libuuid
@@ -52,7 +53,9 @@ test:
     - conda inspect linkages -p $PREFIX libhdfs3
 
 about:
-  home: https://github.com/PivotalRD/libhdfs3
+  # The original GitHub repo at https://github.com/PivotalRD/libhdfs3 is not
+  # available anymore.
+  home: https://github.com/ContinuumIO/libhdfs3-downstream
   license: Apache-2.0
   license_family: Apache
   summary: A Native C/C++ HDFS Client

--- a/recipe/missing-namespace-string-npos.patch
+++ b/recipe/missing-namespace-string-npos.patch
@@ -1,0 +1,20 @@
+diff --git a/libhdfs3/src/client/DataReader.cpp b/libhdfs3/src/client/DataReader.cpp
+index c035c0f..30c627f 100644
+--- a/libhdfs3/src/client/DataReader.cpp
++++ b/libhdfs3/src/client/DataReader.cpp
+@@ -202,7 +202,7 @@ std::vector<char>& DataReader::readResponse(const char* text, int &outsize) {
+             }
+             int offset;
+             int pos = decrypted.find(&buf[0], 0, size);
+-            if (pos == (int)string::npos) {
++            if (pos == (int)std::string::npos) {
+                 THROW(HdfsIOException, "cannot parse wrapped datanode data response: %s",
+                   text);
+             }
+@@ -241,4 +241,4 @@ std::vector<char>& DataReader::readResponse(const char* text, int &outsize) {
+ 
+ 
+ }
+-}
+\ No newline at end of file
++}


### PR DESCRIPTION
This is a plain rebuild against libprotobuf 3.20. This library (libhdfs3) is still widely used but unmaintained. The original project has been abandoned. Anaconda currently keep their own copy at https://github.com/ContinuumIO/libhdfs3-downstream.git

This library is not built for Windows.