### PR TITLE
rebuild against krb 1.20.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,10 +1,3 @@
 # the conda-build parameters to use
 build_parameters:
   - "--suppress-variables"
-
-upload_channels:
-  - marekw
-channels:
-  - marekw
-
-upload_without_merge: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,10 @@
 # the conda-build parameters to use
 build_parameters:
   - "--suppress-variables"
+
+upload_channels:
+  - marekw
+channels:
+  - marekw
+
+upload_without_merge: True

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
 build:
   number: 5
   # This package is a dependency of hdfs3, which is primarily used with HDFS on Linux.
-  # There isn't libboost=1.73 and libgsasl=1.8 on s390x
+  # There isn't libgsasl > 1.8 on s390x
   skip: True  # [win or osx or s390x]
   run_exports:
     # unknown.  Leaving defaults.
@@ -34,13 +34,13 @@ requirements:
     - patch  # [not win]
   host:
     - libprotobuf  # libprotobuf pins itself to x.x via run_exports
-    - libgsasl 1.10
+    - libgsasl 1.10 
     - libntlm
     - libuuid
-    - libxml2 2.10
+    - libxml2
     - krb5 1.20.1
     - libboost  {{ boost }}
-    - openssl
+    - openssl 
     - libcurl
   run:
     - {{ pin_compatible('libboost') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - missing-namespace-string-npos.patch
 
 build:
-  number: 4
+  number: 5
   # This package is a dependency of hdfs3, which is primarily used with HDFS on Linux.
   # There isn't libboost=1.73 and libgsasl=1.8 on s390x
   skip: True  # [win or osx or s390x]
@@ -38,7 +38,7 @@ requirements:
     - libntlm
     - libuuid
     - libxml2 2.10
-    - krb5
+    - krb5 1.20.1
     - libboost  {{ boost }}
     - openssl
     - libcurl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,10 +37,10 @@ requirements:
     - libgsasl 1.10 
     - libntlm
     - libuuid
-    - libxml2
+    - libxml2 {{ libxml2 }}
     - krb5 1.20.1
     - libboost  {{ boost }}
-    - openssl 
+    - openssl {{ openssl }}
     - libcurl
   run:
     - {{ pin_compatible('libboost') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - patch  # [not win]
   host:
     - libprotobuf  # libprotobuf pins itself to x.x via run_exports
-    - libgsasl
+    - libgsasl 1.10
     - libntlm
     - libuuid
     - libxml2 2.10


### PR DESCRIPTION
rebuild against krb 1.20.1
- krb5 strict pinning
- bump up build number