### PR TITLE
Update libprotobuf  pinning.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - missing-namespace-string-npos.patch
 
 build:
-  number: 6
+  number: 7
   # This package is a dependency of hdfs3, which is primarily used with HDFS on Linux.
   # There isn't libgsasl > 1.8 on s390x
   skip: True  # [win or osx or s390x]
@@ -33,7 +33,7 @@ requirements:
     - make   # [linux]
     - patch  # [not win]
   host:
-    - libprotobuf  # libprotobuf pins itself to x.x via run_exports
+    - libprotobuf 5.29.3 # libprotobuf pins itself to x.x via run_exports
     - libgsasl 1.10
     - libntlm
     - libuuid


### PR DESCRIPTION
libhdfs3 libprotobuf5 rebuild

**Destination channel:** {Snowflake | defaults}

### Links

- [PKG-7576](https://anaconda.atlassian.net/browse/PKG-7576) 

- Pin libprotobuf, bump build number. 


[PKG-7576]: https://anaconda.atlassian.net/browse/PKG-7576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ