### PR TITLE
libhdfs3 2.3.0: rebuild against libkrb5

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,3 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/096f9c8
-  - https://staging.continuum.io/prefect/fs/libgsasl-feedstock/pr4/1c50aac
+  - https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/0a7b522
+  - https://staging.continuum.io/prefect/fs/libgsasl-feedstock/pr4/d406a32

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/baedf3b
-  - https://staging.continuum.io/prefect/fs/libgsasl-feedstock/pr4/298d647

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,3 @@
 channels:
   - https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/096f9c8
-  - https://staging.continuum.io/prefect/fs/libgsasl-feedstock/pr4/44b8551
+  - https://staging.continuum.io/prefect/fs/libgsasl-feedstock/pr4/1c50aac

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,3 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/0a7b522
-  - https://staging.continuum.io/prefect/fs/libgsasl-feedstock/pr4/d406a32
+  - https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/baedf3b
+  - https://staging.continuum.io/prefect/fs/libgsasl-feedstock/pr4/298d647

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/096f9c8
+  - https://staging.continuum.io/prefect/fs/libgsasl-feedstock/pr4/44b8551

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,10 +16,9 @@ source:
     - missing-namespace-string-npos.patch
 
 build:
-  number: 6
+  number: 7
   # This package is a dependency of hdfs3, which is primarily used with HDFS on Linux.
-  # There isn't libgsasl > 1.8 on s390x
-  skip: True  # [win or osx or s390x]
+  skip: true  # [win or osx]
   run_exports:
     # unknown.  Leaving defaults.
     - {{ pin_subpackage('libhdfs3') }}
@@ -33,15 +32,15 @@ requirements:
     - make   # [linux]
     - patch  # [not win]
   host:
-    - libprotobuf  # libprotobuf pins itself to x.x via run_exports
-    - libgsasl 1.10
-    - libntlm
-    - libuuid
+    - libprotobuf  {{ libprotobuf }}  # libprotobuf pins itself to x.x via run_exports
+    - libgsasl {{ libgsasl }}
+    - libntlm {{ libntlm }}
+    - libuuid {{ libuuid }}
     - libxml2 {{ libxml2 }}
-    - krb5 1.20.1
+    - libkrb5 {{ krb5 }}
     - libboost  {{ boost }}
     - openssl {{ openssl }}
-    - libcurl
+    - libcurl {{ libcurl }}
   run:
     - {{ pin_compatible('libboost') }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,24 @@ requirements:
 
 test:
   commands:
+    # Test header files
+    - test -f $PREFIX/include/hdfs/BlockLocation.h
+    - test -f $PREFIX/include/hdfs/DirectoryIterator.h
+    - test -f $PREFIX/include/hdfs/Exception.h
+    - test -f $PREFIX/include/hdfs/FileStatus.h
+    - test -f $PREFIX/include/hdfs/FileSystem.h
+    - test -f $PREFIX/include/hdfs/FileSystemStats.h
+    - test -f $PREFIX/include/hdfs/InputStream.h
+    - test -f $PREFIX/include/hdfs/OutputStream.h
+    - test -f $PREFIX/include/hdfs/Permission.h
+    - test -f $PREFIX/include/hdfs/XmlConfig.h
+    - test -f $PREFIX/include/hdfs/hdfs.h
+    # Test library files
     - test -f $PREFIX/lib/libhdfs3.so
+    - test -f $PREFIX/lib/libhdfs3.so.1
+    - test -f $PREFIX/lib/libhdfs3.so.2.2.31
+    - test -f $PREFIX/lib/pkgconfig/libhdfs3.pc
+    # Test linkages
     - conda inspect linkages -p $PREFIX libhdfs3
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - cmake >=3.3


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-9030](https://anaconda.atlassian.net/browse/PKG-9030) 
- [Upstream repository](https://github.com/ContinuumIO/libhdfs3-downstream)
- Issues:
  - https://github.com/ContinuumIO/anaconda-issues/issues/10772
  - https://github.com/conda-forge/krb5-feedstock/issues/48 

### Explanation of changes:

- Rebuild against libkrb5 1.21.3 
- Updated build number from 6 to 7
- Add more tests

### Notes:

- This rebuild addresses downstream dependency issues with krb5 1.21.3

[PKG-9030]: https://anaconda.atlassian.net/browse/PKG-9030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ